### PR TITLE
Merge Pest changes to make it thread-safe

### DIFF
--- a/pest/src/iterators/flat_pairs.rs
+++ b/pest/src/iterators/flat_pairs.rs
@@ -7,6 +7,8 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
+// Note that Rc has been replaced with RefCounted in this Infino fork
+
 use crate::RefCounted;
 use alloc::vec::Vec;
 use core::fmt;

--- a/pest/src/iterators/flat_pairs.rs
+++ b/pest/src/iterators/flat_pairs.rs
@@ -7,7 +7,7 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-use alloc::rc::Rc;
+use crate::RefCounted;
 use alloc::vec::Vec;
 use core::fmt;
 
@@ -25,18 +25,18 @@ pub struct FlatPairs<'i, R> {
     /// # Safety
     ///
     /// All `QueueableToken`s' `input_pos` must be valid character boundary indices into `input`.
-    queue: Rc<Vec<QueueableToken<'i, R>>>,
+    queue: RefCounted<Vec<QueueableToken<'i, R>>>,
     input: &'i str,
     start: usize,
     end: usize,
-    line_index: Rc<LineIndex>,
+    line_index: RefCounted<LineIndex>,
 }
 
 /// # Safety
 ///
 /// All `QueueableToken`s' `input_pos` must be valid character boundary indices into `input`.
 pub unsafe fn new<'i, R: RuleType>(
-    queue: Rc<Vec<QueueableToken<'i, R>>>,
+    queue: RefCounted<Vec<QueueableToken<'i, R>>>,
     input: &'i str,
     start: usize,
     end: usize,
@@ -44,7 +44,7 @@ pub unsafe fn new<'i, R: RuleType>(
     FlatPairs {
         queue,
         input,
-        line_index: Rc::new(LineIndex::new(input)),
+        line_index: RefCounted::new(LineIndex::new(input)),
         start,
         end,
     }
@@ -119,9 +119,9 @@ impl<'i, R: RuleType> Iterator for FlatPairs<'i, R> {
 
         let pair = unsafe {
             pair::new(
-                Rc::clone(&self.queue),
+                RefCounted::clone(&self.queue),
                 self.input,
-                Rc::clone(&self.line_index),
+                RefCounted::clone(&self.line_index),
                 self.start,
             )
         };
@@ -146,9 +146,9 @@ impl<'i, R: RuleType> DoubleEndedIterator for FlatPairs<'i, R> {
 
         let pair = unsafe {
             pair::new(
-                Rc::clone(&self.queue),
+                RefCounted::clone(&self.queue),
                 self.input,
-                Rc::clone(&self.line_index),
+                RefCounted::clone(&self.line_index),
                 self.end,
             )
         };
@@ -168,9 +168,9 @@ impl<'i, R: RuleType> fmt::Debug for FlatPairs<'i, R> {
 impl<'i, R: Clone> Clone for FlatPairs<'i, R> {
     fn clone(&self) -> FlatPairs<'i, R> {
         FlatPairs {
-            queue: Rc::clone(&self.queue),
+            queue: RefCounted::clone(&self.queue),
             input: self.input,
-            line_index: Rc::clone(&self.line_index),
+            line_index: RefCounted::clone(&self.line_index),
             start: self.start,
             end: self.end,
         }

--- a/pest/src/iterators/pair.rs
+++ b/pest/src/iterators/pair.rs
@@ -7,6 +7,8 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
+// Note that Rc has been replaced with RefCounted in this Infino fork
+
 use crate::RefCounted;
 use alloc::format;
 #[cfg(feature = "pretty-print")]

--- a/pest/src/iterators/pair.rs
+++ b/pest/src/iterators/pair.rs
@@ -7,8 +7,8 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
+use crate::RefCounted;
 use alloc::format;
-use alloc::rc::Rc;
 #[cfg(feature = "pretty-print")]
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -41,20 +41,20 @@ pub struct Pair<'i, R> {
     /// # Safety
     ///
     /// All `QueueableToken`s' `input_pos` must be valid character boundary indices into `input`.
-    queue: Rc<Vec<QueueableToken<'i, R>>>,
+    queue: RefCounted<Vec<QueueableToken<'i, R>>>,
     input: &'i str,
     /// Token index into `queue`.
     start: usize,
-    line_index: Rc<LineIndex>,
+    line_index: RefCounted<LineIndex>,
 }
 
 /// # Safety
 ///
 /// All `QueueableToken`s' `input_pos` must be valid character boundary indices into `input`.
 pub unsafe fn new<'i, R: RuleType>(
-    queue: Rc<Vec<QueueableToken<'i, R>>>,
+    queue: RefCounted<Vec<QueueableToken<'i, R>>>,
     input: &'i str,
-    line_index: Rc<LineIndex>,
+    line_index: RefCounted<LineIndex>,
     start: usize,
 ) -> Pair<'i, R> {
     Pair {
@@ -372,7 +372,7 @@ impl<'i, R: RuleType> fmt::Display for Pair<'i, R> {
 
 impl<'i, R: PartialEq> PartialEq for Pair<'i, R> {
     fn eq(&self, other: &Pair<'i, R>) -> bool {
-        Rc::ptr_eq(&self.queue, &other.queue)
+        RefCounted::ptr_eq(&self.queue, &other.queue)
             && ptr::eq(self.input, other.input)
             && self.start == other.start
     }

--- a/pest/src/iterators/pairs.rs
+++ b/pest/src/iterators/pairs.rs
@@ -7,8 +7,8 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
+use crate::RefCounted;
 use alloc::format;
-use alloc::rc::Rc;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
@@ -34,24 +34,24 @@ use crate::RuleType;
 /// [`Pair::into_inner`]: struct.Pair.html#method.into_inner
 #[derive(Clone)]
 pub struct Pairs<'i, R> {
-    queue: Rc<Vec<QueueableToken<'i, R>>>,
+    queue: RefCounted<Vec<QueueableToken<'i, R>>>,
     input: &'i str,
     start: usize,
     end: usize,
     pairs_count: usize,
-    line_index: Rc<LineIndex>,
+    line_index: RefCounted<LineIndex>,
 }
 
 pub fn new<'i, R: RuleType>(
-    queue: Rc<Vec<QueueableToken<'i, R>>>,
+    queue: RefCounted<Vec<QueueableToken<'i, R>>>,
     input: &'i str,
-    line_index: Option<Rc<LineIndex>>,
+    line_index: Option<RefCounted<LineIndex>>,
     start: usize,
     end: usize,
 ) -> Pairs<'i, R> {
     let line_index = match line_index {
         Some(line_index) => line_index,
-        None => Rc::new(LineIndex::new(input)),
+        None => RefCounted::new(LineIndex::new(input)),
     };
 
     let mut pairs_count = 0;
@@ -349,9 +349,9 @@ impl<'i, R: RuleType> Pairs<'i, R> {
         if self.start < self.end {
             Some(unsafe {
                 pair::new(
-                    Rc::clone(&self.queue),
+                    RefCounted::clone(&self.queue),
                     self.input,
-                    Rc::clone(&self.line_index),
+                    RefCounted::clone(&self.line_index),
                     self.start,
                 )
             })
@@ -429,9 +429,9 @@ impl<'i, R: RuleType> DoubleEndedIterator for Pairs<'i, R> {
 
         let pair = unsafe {
             pair::new(
-                Rc::clone(&self.queue),
+                RefCounted::clone(&self.queue),
                 self.input,
-                Rc::clone(&self.line_index),
+                RefCounted::clone(&self.line_index),
                 self.end,
             )
         };
@@ -461,7 +461,7 @@ impl<'i, R: RuleType> fmt::Display for Pairs<'i, R> {
 
 impl<'i, R: PartialEq> PartialEq for Pairs<'i, R> {
     fn eq(&self, other: &Pairs<'i, R>) -> bool {
-        Rc::ptr_eq(&self.queue, &other.queue)
+        RefCounted::ptr_eq(&self.queue, &other.queue)
             && ptr::eq(self.input, other.input)
             && self.start == other.start
             && self.end == other.end

--- a/pest/src/iterators/pairs.rs
+++ b/pest/src/iterators/pairs.rs
@@ -7,6 +7,8 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
+// Note that Rc has been replaced with RefCounted in this Infino fork
+
 use crate::RefCounted;
 use alloc::format;
 use alloc::string::String;

--- a/pest/src/iterators/tokens.rs
+++ b/pest/src/iterators/tokens.rs
@@ -7,7 +7,7 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-use alloc::rc::Rc;
+use crate::RefCounted;
 use alloc::vec::Vec;
 use core::fmt;
 use core::str;
@@ -27,7 +27,7 @@ pub struct Tokens<'i, R> {
     /// # Safety:
     ///
     /// All `QueueableToken`s' `input_pos` must be valid character boundary indices into `input`.
-    queue: Rc<Vec<QueueableToken<'i, R>>>,
+    queue: RefCounted<Vec<QueueableToken<'i, R>>>,
     input: &'i str,
     start: usize,
     end: usize,
@@ -35,7 +35,7 @@ pub struct Tokens<'i, R> {
 
 // TODO(safety): QueueableTokens must be valid indices into input.
 pub fn new<'i, R: RuleType>(
-    queue: Rc<Vec<QueueableToken<'i, R>>>,
+    queue: RefCounted<Vec<QueueableToken<'i, R>>>,
     input: &'i str,
     start: usize,
     end: usize,

--- a/pest/src/iterators/tokens.rs
+++ b/pest/src/iterators/tokens.rs
@@ -7,6 +7,8 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
+// Note that Rc has been replaced with RefCounted in this Infino fork
+
 use crate::RefCounted;
 use alloc::vec::Vec;
 use core::fmt;

--- a/pest/src/lib.rs
+++ b/pest/src/lib.rs
@@ -6,6 +6,9 @@
 // license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
+
+// Note that Rc has been replaced with RefCounted in this Infino fork
+
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/pest-parser/pest/master/pest-logo.svg",

--- a/pest/src/lib.rs
+++ b/pest/src/lib.rs
@@ -334,6 +334,8 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+pub(crate) type RefCounted<T> = std::sync::Arc<T>;
+
 pub use crate::parser::Parser;
 pub use crate::parser_state::{
     set_call_limit, state, Atomicity, Lookahead, MatchDir, ParseResult, ParserState,

--- a/pest/src/parser_state.rs
+++ b/pest/src/parser_state.rs
@@ -10,6 +10,8 @@
 //! The core functionality of parsing grammar.
 //! State of parser during the process of rules handling.
 
+// Note that Rc has been replaced with RefCounted in this Infino fork
+
 use super::RefCounted;
 use alloc::borrow::ToOwned;
 use alloc::boxed::Box;

--- a/pest/src/parser_state.rs
+++ b/pest/src/parser_state.rs
@@ -10,9 +10,9 @@
 //! The core functionality of parsing grammar.
 //! State of parser during the process of rules handling.
 
+use super::RefCounted;
 use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
-use alloc::rc::Rc;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::num::NonZeroUsize;
@@ -179,7 +179,13 @@ where
     match f(state) {
         Ok(state) => {
             let len = state.queue.len();
-            Ok(pairs::new(Rc::new(state.queue), input, None, 0, len))
+            Ok(pairs::new(
+                RefCounted::new(state.queue),
+                input,
+                None,
+                0,
+                len,
+            ))
         }
         Err(mut state) => {
             let variant = if state.reached_call_limit() {


### PR DESCRIPTION
We discovered that Pest, the parser we are using for query processing, [isn't thread-safe](https://github.com/infinohq/infino/pull/195) and will likely impact query performance if we have to parse the grammar for each thread. 

After looking at [nom](https://github.com/rust-bakery/nom) and [lalrpop](https://github.com/lalrpop/lalrpop), and following [this discussion](https://github.com/pest-parser/pest/issues/472#issuecomment-677862761) and [this sample code](https://github.com/SkiFire13/pest/tree/sync-send-feature), we decided the best approach would likely be to fork Pest and try to implement thread-safety ourselves.